### PR TITLE
Avoid extra unpacked copy of Go in the cache dir

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -4,8 +4,7 @@ bash "install-golang" do
   code <<-EOH
     rm -rf go
     rm -rf /usr/local/go
-    tar -xzf #{node["go"]["filename"]}
-    cp -r go /usr/local/
+    tar -C /usr/local -xzf #{node["go"]["filename"]}
   EOH
   action :nothing
 end


### PR DESCRIPTION
The recipe unpacks the tarball, then copies it to /usr/local/go. It's better to avoid the copy and just unpack it there directly.
