### PR TITLE
Using node['go']['install_dir'] as the prefix for the PATH entry.

### DIFF
--- a/files/default/golang.sh
+++ b/files/default/golang.sh
@@ -1,1 +1,0 @@
-export PATH=$PATH:/usr/local/go/bin

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,4 +1,3 @@
-
 bash "install-golang" do
   cwd Chef::Config[:file_cache_path]
   code <<-EOH
@@ -17,9 +16,13 @@ remote_file File.join(Chef::Config[:file_cache_path], node['go']['filename']) do
   not_if "#{node['go']['install_dir']}/go/bin/go version | grep #{node['go']['version']}"
 end
 
-cookbook_file "/etc/profile.d/golang.sh" do
-  source "golang.sh"
-  owner "root"
-  group "root"
+template '/etc/profile.d/golang.sh' do
+  cookbook 'golang'
+  source 'golang.sh.erb'
+  owner 'root'
+  group 'root'
   mode 0755
+  variables({
+    install_dir: node['go']['install_dir']
+  })
 end

--- a/templates/default/golang.sh.erb
+++ b/templates/default/golang.sh.erb
@@ -1,0 +1,1 @@
+export PATH="$PATH:<%= @install_dir %>/go/bin"


### PR DESCRIPTION
With this change, if a user specifies a different
`node['go']['install_dir']`, that install_dir will also be used as the
prefix for the PATH entry in `/etc/profile.d/golang.sh`.  This ensures
that the correct `go` executable can be found.
