### PR TITLE
Update metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,8 @@ recipe "golang", "Installs go programing language."
 recipe "golang::install", "Installs go programing language."
 recipe "golang::requirements", "Installs requirements."
 
-supports 'debian', ">= 6.0"
-supports 'ubuntu', ">= 12.04"
+supports 'debian'
+supports 'ubuntu'
 
 depends 'git'
+


### PR DESCRIPTION
We shouldn't strict OS versions, imho.

This is because you couldn't actually know whenever this cookbook works
on platforms with lower versions (e.g. Ubuntu 10.04). Just for the info,
it works on Ubuntu 10.04.
