### PR TITLE
Create the bin directory with the go owner/group

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,8 +46,8 @@ end
 directory node['go']['gobin'] do
   action :create
   recursive true
-  owner 'root'
-  group 'root'
+  owner node['go']['owner']
+  group node['go']['group']
   mode 0755
 end
 


### PR DESCRIPTION
Installing packages fail with permissions errors when go.owner is set to something not root.
