### PR TITLE
Package location has changed to http://golang.org/dl/

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 default['go']['version'] = '1.2'
 default['go']['platform'] = 'amd64'
 default['go']['filename'] = "go#{node['go']['version']}.#{node['os']}-#{node['go']['platform']}.tar.gz"
-default['go']['url'] = "http://go.googlecode.com/files/#{node['go']['filename']}"
+default['go']['url'] = "http://golang.org/dl/#{node['go']['filename']}"
 default['go']['install_dir'] = '/usr/local'
 default['go']['gopath'] = '/opt/go'
 default['go']['gobin'] = '/opt/go/bin'


### PR DESCRIPTION
Hence the current cookbook returns a 404 when trying to download the tar ball.
