### PR TITLE
Refactor source build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,10 @@ jobs:
         with:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}
+
+  final:
+    needs: [dokken]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This file is used to list changes made in each version of golang.
 - Use `build_essential` when building from source
   - Requires Chef >= 14.0.0
 - Omit attempting to install `bzr` on CentOS 8, they do not have that package available
+- Utilize default Chef order-of-operations instead of `notifies`
+- Use `ark` resource to simplify download & installation of binary & source
+- Clean up unnecessary env vars from source build
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This file is used to list changes made in each version of golang.
 - Utilize default Chef order-of-operations instead of `notifies`
 - Use `ark` resource to simplify download & installation of binary & source
 - Clean up unnecessary env vars from source build
+- Build from source per [official Go docs](https://golang.org/doc/install/source)
+- Use native resources instead of shell commands when building from source
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This file is used to list changes made in each version of golang.
 - Update default version to Go v1.14.4
 - Use `build_essential` when building from source
   - Requires Chef >= 14.0.0
+- Omit attempting to install `bzr` on CentOS 8, they do not have that package available
 
 ## 3.0.0
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,12 +2,11 @@ default['golang']['version'] = '1.14.4'
 default['golang']['platform'] = node['kernel']['machine'] =~ /i.86/ ? '386' : 'amd64'
 default['golang']['filename'] = "go#{node['golang']['version']}.#{node['os']}-#{node['golang']['platform']}.tar.gz"
 default['golang']['from_source'] = false
-if node['golang']['from_source']
-  default['golang']['filename'] = "go#{node['golang']['version']}.src.tar.gz"
-  default['golang']['source_method'] = 'all.bash'
-end
+default['golang']['src_filename'] = "go#{node['golang']['version']}.src.tar.gz"
+default['golang']['source_method'] = 'all.bash'
 # E.g., https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz
 default['golang']['url'] = "https://dl.google.com/go/#{node['golang']['filename']}"
+default['golang']['source_url'] = "https://dl.google.com/go/#{node['golang']['src_filename']}"
 default['golang']['install_dir'] = '/usr/local'
 default['golang']['gopath'] = '/opt/go'
 default['golang']['gobin'] = '/opt/go/bin'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,9 +4,6 @@ default['golang']['filename'] = "go#{node['golang']['version']}.#{node['os']}-#{
 default['golang']['from_source'] = false
 if node['golang']['from_source']
   default['golang']['filename'] = "go#{node['golang']['version']}.src.tar.gz"
-  default['golang']['os'] = 'linux'
-  default['golang']['arch'] = 'arm'
-  default['golang']['arm'] = '6'
   default['golang']['source_method'] = 'all.bash'
 end
 # E.g., https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,7 +15,10 @@ default['golang']['install_dir'] = '/usr/local'
 default['golang']['gopath'] = '/opt/go'
 default['golang']['gobin'] = '/opt/go/bin'
 default['golang']['scm'] = true
-default['golang']['scm_packages'] = %w(git mercurial bzr)
+default['golang']['scm_packages'] = value_for_platform(
+  'centos' => { '>= 8' => %w(git mercurial) },
+  'default' => %w(git mercurial bzr)
+)
 default['golang']['packages'] = []
 default['golang']['owner'] = 'root'
 default['golang']['group'] = 'root'

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,3 +16,5 @@ supports 'fedora'
 supports 'amazon'
 supports 'scientific'
 supports 'oracle'
+
+depends 'ark', '~> 5.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,51 +17,6 @@
 # under the License.
 #
 
-bash 'install-golang' do
-  cwd Chef::Config[:file_cache_path]
-  code <<-EOH
-    rm -rf go
-    rm -rf #{node['golang']['install_dir']}/go
-    tar -C #{node['golang']['install_dir']} -xzf #{node['golang']['filename']}
-  EOH
-  not_if { node['golang']['from_source'] }
-  action :nothing
-end
-
-build_essential do
-  only_if { node['golang']['from_source'] }
-end
-
-bash 'build-golang' do
-  cwd Chef::Config[:file_cache_path]
-  code <<-EOH
-    rm -rf go
-    rm -rf #{node['golang']['install_dir']}/go
-    tar -C #{node['golang']['install_dir']} -xzf #{node['golang']['filename']}
-    cd #{node['golang']['install_dir']}/go/src
-    mkdir -p $GOBIN
-    ./#{node['golang']['source_method']}
-  EOH
-  environment({
-    'GOROOT' => "#{node['golang']['install_dir']}/go",
-    'GOBIN'  => '$GOROOT/bin',
-    'GOOS'   => node['golang']['os'],
-    'GOARCH' => node['golang']['arch'],
-    'GOARM'  => node['golang']['arm'],
-  })
-  only_if { node['golang']['from_source'] }
-  action :nothing
-end
-
-remote_file File.join(Chef::Config[:file_cache_path], node['golang']['filename']) do
-  source node['golang']['url']
-  owner 'root'
-  mode '0644'
-  notifies :run, 'bash[install-golang]', :immediately
-  notifies :run, 'bash[build-golang]', :immediately
-  not_if "#{node['golang']['install_dir']}/go/bin/go version | grep \"go#{node['golang']['version']} \""
-end
-
 directory node['golang']['gopath'] do
   action :create
   recursive true
@@ -93,4 +48,38 @@ if node['golang']['scm']
   node['golang']['scm_packages'].each do |scm|
     package scm
   end
+end
+
+ark 'go' do
+  url node['golang']['url']
+  version node['golang']['version']
+end
+
+build_essential do
+  only_if { node['golang']['from_source'] }
+end
+
+remote_file File.join(Chef::Config[:file_cache_path], node['golang']['filename']) do
+  source node['golang']['url']
+  owner 'root'
+  mode '0644'
+  not_if "#{node['golang']['install_dir']}/go/bin/go version | grep \"go#{node['golang']['version']} \""
+end
+
+bash 'build-golang' do
+  cwd Chef::Config[:file_cache_path]
+  code <<-EOH
+    rm -rf go
+    rm -rf #{node['golang']['install_dir']}/go
+    tar -C #{node['golang']['install_dir']} -xzf #{node['golang']['filename']}
+    cd #{node['golang']['install_dir']}/go/src
+    mkdir -p $GOBIN
+    ./#{node['golang']['source_method']}
+  EOH
+  environment({
+    GOROOT: "#{node['golang']['install_dir']}/go",
+    GOBIN: "#{node['golang']['install_dir']}/go/bin",
+  })
+  only_if { node['golang']['from_source'] }
+  action :nothing
 end

--- a/test/integration/src
+++ b/test/integration/src
@@ -1,1 +1,0 @@
-default


### PR DESCRIPTION
# Description

* Cleans up the recipe, using Chef’s order-of-operations instead of `notifies`
* Leverages the `ark` cookbook to avoid shelling out with `bash`
* Avoids using shell commands in favor of native resources
* Builds Go from source per [the official docs](https://golang.org/doc/install/source)

## Issues Resolved

None

## Check List

- [x] All tests pass. See TESTING.md for details.
    - This is largely dependent on if the build completes, which is beyond the scope of this cookbook once it is, in fact, building correctly
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
