### PR TITLE
Clean up golang_package resource, allow package & source to install different versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This file is used to list changes made in each version of golang.
 - Clean up unnecessary env vars from source build
 - Build from source per [official Go docs](https://golang.org/doc/install/source)
 - Use native resources instead of shell commands when building from source
+- Set `$PATH` in `golang.sh` so that the existing values are last, per general practice
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This file is used to list changes made in each version of golang.
 - Use native resources instead of shell commands when building from source
 - Set `$PATH` in `golang.sh` so that the existing values are last, per general practice
 - Tighten up `golang_package` so it does not perform actions at compile time, it uses `execute` in favor of `bash` resources, and in general is more Chef-y
+- Update tests to validate that non-root users can install Go and Go packages
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This file is used to list changes made in each version of golang.
 - Build from source per [official Go docs](https://golang.org/doc/install/source)
 - Use native resources instead of shell commands when building from source
 - Set `$PATH` in `golang.sh` so that the existing values are last, per general practice
+- Tighten up `golang_package` so it does not perform actions at compile time, it uses `execute` in favor of `bash` resources, and in general is more Chef-y
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This file is used to list changes made in each version of golang.
 - Set `$PATH` in `golang.sh` so that the existing values are last, per general practice
 - Tighten up `golang_package` so it does not perform actions at compile time, it uses `execute` in favor of `bash` resources, and in general is more Chef-y
 - Update tests to validate that non-root users can install Go and Go packages
+- Refactor attributes to add ability to install a version from source that differs from the packaged version (which is needed to build from source)
 
 ## 3.0.0
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Chef cookbook for the [Go programming language](http://golang.org/).
 
 ### golang::default
 
-Just include `golang` in your node's `run_list`:
+Include `golang` in your node's `run_list`:
 
 ```json
 {
@@ -50,25 +50,6 @@ To install Go packages using node attributes, include `golang::packages` in your
   ]
 }
 ```
-
-## Attributes
-
-### golang::default
-
-Key | Type | Description | Default
---- | ---- | ----------- | -------
-`['golang']['version']` | String | Go version | `1.5`
-`['golang']['platform']` | String | `amd64` or `i386` | `amd64`
-`['golang']['scm']` | Boolean | install SCM dependencies `git`, `hg`, and `bzr` | `true`
-`['golang']['packages']` | Array | Go packages to install when using the `golang::packages` recipe | `[]`
-`['golang']['owner']` | String | The user account that owns $GOPATH | `root`
-`['golang']['group']` | String | The group that owns $GOPATH | `root`
-`['golang']['mode']` | String | The mode of $GOPATH | `0755`
-`['golang']['from_source']` | Boolean | Install go from source | `false`
-`['golang']['os']` | String | Build go for which operating system | `linux`
-`['golang']['arch']` | String | Build go for which architecture | `arm`
-`['golang']['arm']` | String | Build go for which arm version | `6`
-`['golang']['source_method']` | String | Choose which install script should be used | `all.bash`
 
 ## Contributors
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,12 +1,8 @@
 default['golang']['version'] = '1.14.4'
 default['golang']['platform'] = node['kernel']['machine'] =~ /i.86/ ? '386' : 'amd64'
 default['golang']['filename'] = "go#{node['golang']['version']}.#{node['os']}-#{node['golang']['platform']}.tar.gz"
-default['golang']['from_source'] = false
-default['golang']['src_filename'] = "go#{node['golang']['version']}.src.tar.gz"
-default['golang']['source_method'] = 'all.bash'
 # E.g., https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz
 default['golang']['url'] = "https://dl.google.com/go/#{node['golang']['filename']}"
-default['golang']['source_url'] = "https://dl.google.com/go/#{node['golang']['src_filename']}"
 default['golang']['install_dir'] = '/usr/local'
 default['golang']['gopath'] = '/opt/go'
 default['golang']['gobin'] = '/opt/go/bin'
@@ -19,3 +15,9 @@ default['golang']['packages'] = []
 default['golang']['owner'] = 'root'
 default['golang']['group'] = 'root'
 default['golang']['mode'] = '0755'
+
+default['golang']['from_source'] = false
+default['golang']['src_version'] = node['golang']['version']
+default['golang']['src_filename'] = "go#{node['golang']['src_version']}.src.tar.gz"
+default['golang']['source_method'] = 'all.bash'
+default['golang']['source_url'] = "https://dl.google.com/go/#{node['golang']['src_filename']}"

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -38,4 +38,3 @@ suites:
     attributes:
       golang:
         from_source: true
-        arch: 'amd64'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -16,7 +16,6 @@ verifier:
     - test/integration/default
 
 platforms:
-
   - name: ubuntu-18.04
   - name: ubuntu-20.04
   - name: centos-7
@@ -28,6 +27,11 @@ suites:
   - name: default
     run_list:
       - recipe[golang_test::default]
+    attributes:
+      golang:
+        owner: golang
+        group: golang
+
   - name: src
     run_list:
       - recipe[golang_test::default]

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -12,8 +12,6 @@ provisioner:
 
 verifier:
   name: inspec
-  inspec_tests:
-    - test/integration/default
 
 platforms:
   - name: ubuntu-18.04
@@ -38,3 +36,4 @@ suites:
     attributes:
       golang:
         from_source: true
+        src_version: 1.13.12

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,6 @@
 #
 
 directory node['golang']['gopath'] do
-  action :create
   recursive true
   owner node['golang']['owner']
   group node['golang']['group']
@@ -26,7 +25,6 @@ directory node['golang']['gopath'] do
 end
 
 directory node['golang']['gobin'] do
-  action :create
   recursive true
   owner node['golang']['owner']
   group node['golang']['group']

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -1,81 +1,47 @@
 default_action :install
 
+gocache = '/tmp/go'
+
 action :install do
-  tmp_dir_path = ::File.join Chef::Config[:file_cache_path], 'golang'
-  tmp_file_path = ::File.join tmp_dir_path, new_resource.name.gsub(%r{/}, '-')
-
-  directory tmp_dir_path do
+  execute "go get #{new_resource.name}" do
     user node['golang']['owner']
     group node['golang']['group']
-    mode '0775'
-    action :nothing
-  end.run_action(:create)
-
-  bash "Installing package #{new_resource.name}" do
-    code "#{node['golang']['install_dir']}/go/bin/go get -v #{new_resource.name} 2> >(grep -v '(download)$' | tee #{tmp_file_path})"
-    action :nothing
-    user node['golang']['owner']
-    group node['golang']['group']
-    environment(
-      'GOPATH' => node['golang']['gopath'],
-      'GOBIN' => node['golang']['gobin']
-    )
-  end.run_action(:run)
-
-  f = file tmp_file_path do
-    user node['golang']['owner']
-    group node['golang']['group']
-    content ''
+    environment({
+      PATH: "#{node['golang']['install_dir']}/go/bin:#{node['golang']['gobin']}:" \
+            '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      GOPATH: node['golang']['gopath'],
+      GOBIN: node['golang']['gobin'],
+      GOCACHE: gocache,
+    })
   end
-  f.run_action(:create)
 end
 
 action :update do
-  tmp_file_path = ::File.join Chef::Config[:file_cache_path], new_resource.name.gsub(%r{/}, '-')
-
-  bash "Updating package #{new_resource.name}" do
-    code "#{node['golang']['install_dir']}/go/bin/go get -v -u #{new_resource.name} 2> >(grep -v '(download)$' | tee #{tmp_file_path})"
-    action :nothing
+  execute "go get -u #{new_resource.name}" do
     user node['golang']['owner']
     group node['golang']['group']
-    environment(
-      'GOPATH' => node['golang']['gopath'],
-      'GOBIN' => node['golang']['gobin']
-    )
-  end.run_action(:run)
-
-  f = file tmp_file_path do
-    content ''
+    environment({
+      PATH: "#{node['golang']['install_dir']}/go/bin:#{node['golang']['gobin']}:" \
+            '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      GOPATH: node['golang']['gopath'],
+      GOBIN: node['golang']['gobin'],
+      GOCACHE: gocache,
+    })
   end
-  f.run_action(:create)
 end
 
 action :build do
-  tmpdir = directory(::File.join(Chef::Config[:file_cache_path], new_resource.name.gsub(%r{/}, '-') + '_BUILD')) do
-    action :nothing
-    owner node['golang']['owner']
-    group node['golang']['group']
-    recursive true
-  end
-
-  # create temporary directory to executing the build in
-  tmpdir.run_action(:create)
-
-  b = bash "Build package #{new_resource.name}" do
-    code "#{node['golang']['install_dir']}/go/bin/go build #{new_resource.name}"
-    action :nothing
-    cwd tmpdir.name
+  execute "go build -work -x #{new_resource.name}" do
     user node['golang']['owner']
     group node['golang']['group']
-    environment(
-      'GOPATH' => node['golang']['gopath'],
-      'GOBIN' => node['golang']['gobin']
-    )
+    cwd gocache
+    environment({
+      PATH: "#{node['golang']['install_dir']}/go/bin:#{node['golang']['gobin']}:" \
+            '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      HOME: "/home/#{node['golang']['owner']}",
+      GOPATH: node['golang']['gopath'],
+      GOBIN: node['golang']['gobin'],
+      GOCACHE: gocache,
+    })
   end
-
-  # execute the build
-  b.run_action(:run)
-
-  # remove temporary directory
-  # tmpdir.run_action(:delete)
 end

--- a/templates/default/golang.sh.erb
+++ b/templates/default/golang.sh.erb
@@ -1,3 +1,3 @@
-export PATH=$PATH:<%= node['golang']['install_dir'] %>/go/bin:<%= node['golang']['gobin'] %>
+export PATH="<%= node['golang']['install_dir'] %>/go/bin:<%= node['golang']['gobin'] %>:$PATH"
 export GOPATH=<%= node['golang']['gopath'] %>
 export GOBIN=<%= node['golang']['gobin'] %>

--- a/test/integration/cookbooks/golang_test/recipes/default.rb
+++ b/test/integration/cookbooks/golang_test/recipes/default.rb
@@ -17,6 +17,10 @@
 # under the License.
 #
 
+user node['golang']['owner'] do
+  manage_home true
+end
+
 include_recipe 'golang::packages'
 
 golang_package 'github.com/go-check/check'

--- a/test/integration/default/default_test.rb
+++ b/test/integration/default/default_test.rb
@@ -7,8 +7,8 @@ describe command 'export GOPATH=/opt/go; cd /tmp/hello_world && /usr/local/go/bi
 end
 
 describe directory '/opt/go' do
-  its('owner') { should eq 'root' }
-  its('group') { should eq 'root' }
+  its('owner') { should eq 'golang' }
+  its('group') { should eq 'golang' }
 end
 
 describe command '/opt/go/bin/hello' do

--- a/test/integration/src/default_test.rb
+++ b/test/integration/src/default_test.rb
@@ -1,0 +1,16 @@
+describe command '/usr/local/go/bin/go version' do
+  its('stdout') { should include '1.13.12' }
+end
+
+describe command 'export GOPATH=/opt/go; cd /tmp/hello_world && /usr/local/go/bin/go test' do
+  its('exit_status') { should cmp 0 }
+end
+
+describe directory '/opt/go' do
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
+end
+
+describe command '/opt/go/bin/hello' do
+  its('stdout') { should include 'Hello, Go examples!' }
+end


### PR DESCRIPTION
# Description

The `golang_package` resource now runs during the normal convergence, and is cleaner.

Additionally, provide the ability to use one version of Go via packages to build a different version from source.

## Issues Resolved

Fixes #54 (again)

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
