### PR TITLE
[bugfix] Fix gopath in environment template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of golang.
 
 ## Unreleased
 
+## 5.0.2 - *2021-06-02*
+
+- Fix resource to use the correct path in GOPATH profile.d template
+
 ## 5.0.1 - *2021-06-01*
 
 ## 5.0.0 - *2021-05-21*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ This file is used to list changes made in each version of golang.
 
 ## Unreleased
 
-
 - Fix resource to use the correct path in GOPATH profile.d template
 
 ## 5.0.1 - *2021-06-01*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ This file is used to list changes made in each version of golang.
 
 ## Unreleased
 
-## 5.0.2 - *2021-06-02*
 
 - Fix resource to use the correct path in GOPATH profile.d template
 

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -101,7 +101,7 @@ action :install do
     source 'golang.sh.erb'
     mode new_resource.directory_mode
     variables gobin: new_resource.gobin,
-              gopath:  new_resource.gobin,
+              gopath:  new_resource.gopath,
               install_dir: new_resource.install_dir
   end
 


### PR DESCRIPTION
# Description

Currently GOPATH is set to GOBIN, which is unconventionnal (and obviously a mistake)

## Issues Resolved

GOPATH was incorrect

## Check List

- [x] All tests pass. See TESTING.md for details.
