### PR TITLE
Use install_dir node attribute in default recipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,12 @@ jobs:
         suite:
           - default
           - source
+          - install-dir
         exclude:
           - os: fedora-latest
             suite: source
+          - os: fedora-latest
+            suite: install-dir
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of golang.
 
 ## Unreleased
 
+- Use `node['golang']['install_dir']` attribute in default recipe.
+
 ## 5.3.3 - *2022-08-07*
 
 Standardise files with files in sous-chefs/repo-management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of golang.
 ## Unreleased
 
 - Use `node['golang']['install_dir']` attribute in default recipe.
+- Fix source installation issues
 
 ## 5.3.3 - *2022-08-07*
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -3,9 +3,13 @@ driver:
   name: dokken
   privileged: true
 
-transport: { name: dokken }
-provisioner: { name: dokken }
-verifier: { name: inspec }
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_license: accept-no-persist
 
 platforms:
   - name: almalinux-8

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -44,3 +44,14 @@ suites:
         source_version: 1.13.12
         owner: golang
         group: golang
+
+  - name: install-dir
+    run_list:
+      - recipe[test::default]
+    attributes:
+      golang:
+        from_source: true
+        source_version: 1.13.12
+        owner: golang
+        group: golang
+        install_dir: /srv

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,7 @@
 golang 'Install go' do
   from_source node['golang']['from_source']
   version node['golang']['version'] if node['golang']['version'] # go version
+  install_dir node['golang']['install_dir'] if node['golang']['install_dir'] # go install_dir - e.g. /opt or /usr/local
   source_version node['golang']['source_version'] if node['golang']['source_version'] # go version from source
   scm node['golang']['scm']
   scm_packages node['golang']['scm_packages']

--- a/test/integration/install-dir/default_test.rb
+++ b/test/integration/install-dir/default_test.rb
@@ -1,8 +1,8 @@
-describe command '/usr/local/go/bin/go version' do
+describe command '/srv/go/bin/go version' do
   its('stdout') { should include '1.13.12' }
 end
 
-describe command 'export GOPATH=/opt/go; cd /tmp/helloWorld && /usr/local/go/bin/go test' do
+describe command 'export GOPATH=/opt/go; cd /tmp/helloWorld && /srv/go/bin/go test' do
   its('exit_status') { should cmp 0 }
 end
 
@@ -13,4 +13,8 @@ end
 
 describe command '/opt/go/bin/hello' do
   its('stdout') { should include 'Hello, Go examples!' }
+end
+
+describe directory '/opt/kitchen/cache/go-bootstrap' do
+  it { should_not exist }
 end

--- a/test/integration/source/default_test.rb
+++ b/test/integration/source/default_test.rb
@@ -1,0 +1,20 @@
+describe command '/usr/local/go/bin/go version' do
+  its('stdout') { should include '1.13.12' }
+end
+
+describe command 'export GOPATH=/opt/go; cd /tmp/helloWorld && /usr/local/go/bin/go test' do
+  its('exit_status') { should cmp 0 }
+end
+
+describe directory '/opt/go' do
+  its('owner') { should eq 'golang' }
+  its('group') { should eq 'golang' }
+end
+
+describe command '/opt/go/bin/hello' do
+  its('stdout') { should include 'Hello, Go examples!' }
+end
+
+describe directory '/opt/kitchen/cache/go-bootstrap' do
+  it { should_not exist }
+end


### PR DESCRIPTION
# Description

If the `install_dir` node attribute is set, this will use it in the default recipe for installing go. 

## Issues Resolved

None

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
