### PR TITLE
Fix unified_mode declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of golang.
 
 ## Unreleased
 
+- Fix `unified_mode` declaration
+- Bump `ark` dependency to one with `unified_mode` set
+
 ## 5.2.0 - *2021-06-04*
 
 - Update example package to adhere with modern Go standards

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -2,7 +2,6 @@
 driver:
   name: dokken
   privileged: true
-  env: [CHEF_LICENSE=accept]
 
 transport:
   name: dokken
@@ -11,6 +10,7 @@ provisioner:
   name: dokken
   product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
+  chef_license: accept-no-persist
   install_strategy: once
 
 platforms:

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,4 +17,4 @@ supports 'amazon'
 supports 'scientific'
 supports 'oracle'
 
-depends 'ark', '~> 6.0'
+depends 'ark', '>= 6.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,4 +17,4 @@ supports 'amazon'
 supports 'scientific'
 supports 'oracle'
 
-depends 'ark', '~> 5.0'
+depends 'ark', '~> 6.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: golang
 # Recipe:: default
 #
-# Copyright:: 2013, Alexander Rozhnov
+# Copyright:: 2013-2021, Alexander Rozhnov
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: golang
 # Resource:: default
 #
-# Copyright:: 2020, Sous-chefs
+# Copyright:: 2020-2021, Sous-chefs
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy
@@ -16,6 +16,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
+
+unified_mode true
 
 # Install golang by compiling from source
 property :from_source, [true, false], default: false
@@ -50,8 +52,6 @@ property :source_method, String, default: 'all.bash'
 # install SCM packages
 property :scm, [true, false], default: true
 property :scm_packages, [String, Array], default: %w(git mercurial)
-
-unified_mode
 
 action_class do
   def bin_url

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -2,6 +2,20 @@
 # Cookbook:: golang
 # Resource:: default
 #
+# Copyright:: 2020-2021, Sous-chefs
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
 
 unified_mode true
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: golang
 # Spec:: default
 #
-# Copyright:: 2020, Jeff Byrnes
+# Copyright:: 2020-2021, Jeff Byrnes
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/integration/cookbooks/golang_test/recipes/default.rb
+++ b/test/integration/cookbooks/golang_test/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: golang_test
 # Recipe:: default
 #
-# Copyright:: 2020, Sous Chefs
+# Copyright:: 2020-2021, Sous Chefs
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy


### PR DESCRIPTION
Signed-off-by: Robert Detjens <detjensrobert@osuosl.org>

# Description

The previous PR (#92) did not properly set unified_mode for the default install resource.

This PR also bumps the pinned `ark` dependency to one with unified_mode enabled.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
