### PR TITLE
ci: use sous-chefs workflows 8.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
       - name: Install Cinc Workstation
-        uses: sous-chefs/.github/.github/actions/install-workstation@6.0.0
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.1
       - name: Dokken
         uses: actionshub/test-kitchen@3.0.0
         env:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
       - name: Install Cinc Workstation
-        uses: sous-chefs/.github/.github/actions/install-workstation@6.0.0
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.1
       - name: Install cookbooks
         run: berks install


### PR DESCRIPTION
Update reusable Sous Chefs workflow calls to 8.0.1.

This removes local workflow trusted-author overrides so repositories inherit the central policy from sous-chefs/.github.